### PR TITLE
Fix for use in electron app

### DIFF
--- a/helper/xbogus.js
+++ b/helper/xbogus.js
@@ -6,7 +6,7 @@ function _0x5cd844(e) {
     };
     return e(b, b.exports), b.exports
 }
-jsvmp = function(e, b, a) {
+let jsvmp = function(e, b, a) {
     function f(e, b, a) {
         return (f = function() {
             if ("undefined" == typeof Reflect || !Reflect.construct || Reflect.construct.sham) return !1;


### PR DESCRIPTION
Hi I was using this with an electron app but found it didnt start up corrrectly with this error.
This fix defines the jsvmp funxtion and allows the app to run.

```App threw an error during load
ReferenceError: jsvmp is not defined       
    at Object.<anonymous> (D:\NewCode\autot    at Module._compile (node:internal/modules/cjs/loader:1484:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1564:10)
    at Module.load (node:internal/modules/cjs/loader:1295:32)
    at Module._load (node:internal/modules/cjs/loader:1111:12)
    at c._load (node:electron/js2c/node_init:2:16955)
    at cjsLoader (node:internal/modules/esm/translators:350:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:286:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)```


    