### PR TITLE
Fix: Handle Tiktok Music URLs in v2(sssTik)

### DIFF
--- a/src/types/downloader/ssstik.ts
+++ b/src/types/downloader/ssstik.ts
@@ -8,13 +8,14 @@ export type SSSTikResponse = {
   status: "success" | "error"
   message?: string
   result?: {
-    type: "image" | "video"
+    type: "image" | "video" | "music"
     desc?: string
-    author: Author
-    statistics: Statistics
+    author?: Author
+    statistics?: Statistics
     images?: string[]
     video?: string
     music?: string
+    direct?: string
   }
 }
 

--- a/src/utils/downloader/ssstik.ts
+++ b/src/utils/downloader/ssstik.ts
@@ -5,7 +5,7 @@ import {
   Author,
   Statistics,
   SSSTikFetchTT,
-  SSSTikResponse
+  SSSTikResponse,
 } from "../../types/downloader/ssstik"
 import { _ssstikapi, _ssstikurl } from "../../constants/api"
 import { HttpsProxyAgent } from "https-proxy-agent"
@@ -132,6 +132,7 @@ export const SSSTik = (url: string, proxy?: string): Promise<SSSTikResponse> =>
       // Video & Music Result
       const video = $("a.without_watermark").attr("href")
       const music = $("a.music").attr("href")
+      const direct = $("a.music_direct").attr("href")
 
       // Images / Slide Result
       const images: string[] = []
@@ -168,7 +169,15 @@ export const SSSTik = (url: string, proxy?: string): Promise<SSSTikResponse> =>
         if (music) {
           result.music = music
         }
+      } else if (music) {
+        // Music Result
+        result = {
+          type: "music",
+          music,
+          direct: direct || "",
+        }
       }
+
       resolve({ status: "success", result })
     } catch (err) {
       resolve({ status: "error", message: err.message })


### PR DESCRIPTION
## **Pull Request: Fix Music URL Handling in v2 (SSSTik)**

### **Issue Overview**
Previously, when the `v2 (SSSTik)` method in this package received a TikTok music URL (e.g., `https://www.tiktok.com/music/original-sound-7441643152500362014`), it returned an incomplete response with `result: undefined`. 

#### Example of the old response:
```json
{
  "status": "success",
  "result": undefined
}
```
This behavior caused the package to fail when handling TikTok music URLs, which limited its functionality.

### **Solution Implemented**
- Updated the logic in the v2 (SSSTik) method to properly handle TikTok music URLs.
#### Example of the fixed response:
```json
{
  "status": "success",
  "result": {
    "type": "music",
    "music": "https://tikcdn.io/ssstik/aHR0cHM6Ly9zZjE2LnRpa3Rva2Nkbi11cy5jb20vb2JqL2llcy1tdXNpYy10eDIvNzQ0MTY0MzI3ODA3MzYyOTQ3MS5tcDM=",
    "direct": "https://sf16.tiktokcdn-us.com/obj/ies-music-tx2/7441643278073629471.mp3"
  }
}
```
