### PR TITLE
fix: query multiple posts from a user

### DIFF
--- a/src/utils/get/getProfile.ts
+++ b/src/utils/get/getProfile.ts
@@ -158,9 +158,9 @@ const parsePosts = async (
   let hasMore = true
   let cursor: number | null = null
   const posts: Posts[] = []
+  let counter = 0
   while (hasMore) {
     let result: any | null = null
-    let counter = 0
 
     // Prevent missing response posts
     for (let i = 0; i < 30; i++) {
@@ -246,8 +246,10 @@ const parsePosts = async (
     // Restrict too many data requests
     if (postLimit !== 0) {
       let loopCount = Math.floor(postLimit / 30)
-      if (counter >= loopCount) hasMore = false
-      break
+      if (counter >= loopCount) {
+        hasMore = false
+        break
+      }
     }
 
     hasMore = result.hasMore


### PR DESCRIPTION
I found a bug: When I tried to query a user's videos, even though I set the postLimit parameter, it didn't take effect.
There are two places that caused this bug.
1. The counter variable is initialized to 0 in the loop, so even if you increase it after the loop ends, it won't take effect.
2. if postLimit is not 0, after making one query, the loop will be exited.