### PR TITLE
fix(v3): repair musicalDown broken logics

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -14,6 +14,8 @@ export const _tiktokGetUserLiked = (params: any): string =>
   `${_tiktokurl}/api/favorite/item_list/?${params}`
 export const _tiktokGetCollection = (params: any): string =>
   `${_tiktokurl}/api/collection/item_list/?${params}`
+export const _tiktokGetPlaylist = (params: any): string =>
+  `${_tiktokurl}/api/mix/item_list/?${params}`
 
 /** Tiktokv */
 export const _tiktokvApi: string = `https://api16-normal-useast5.tiktokv.us`

--- a/src/constants/params.ts
+++ b/src/constants/params.ts
@@ -353,7 +353,11 @@ const generateOdinId = () => {
   return `${prefix}${random}`
 }
 
-export const _getCollectionParams = (collectionId: string, page: number = 1, count: number = 5) => {
+export const _getCollectionParams = (
+  collectionId: string,
+  page: number = 1,
+  count: number = 5
+) => {
   let cursor = 0
   if (page > 0) {
     cursor = (page - 1) * count
@@ -368,7 +372,8 @@ export const _getCollectionParams = (collectionId: string, page: number = 1, cou
     browser_name: "Mozilla",
     browser_online: true,
     browser_platform: "Win32",
-    browser_version: "5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+    browser_version:
+      "5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
     channel: "tiktok_web",
     collectionId,
     cookie_enabled: true,
@@ -391,6 +396,60 @@ export const _getCollectionParams = (collectionId: string, page: number = 1, cou
     screen_height: 1440,
     screen_width: 2560,
     sourceType: 113,
+    tz_name: "Pacific/Auckland",
+    user_is_login: true,
+    verifyFp: "verify_lacphy8d_z2ux9idt_xdmu_4gKb_9nng_NNTTTvsFS8ao",
+    webcast_language: "en"
+  })
+}
+
+export const _getPlaylistParams = (
+  playlistId: string,
+  page: number = 1,
+  /**
+   * @max 20
+   * @default 5
+   */
+  count: number = 5
+) => {
+  count = Math.min(Math.max(1, count), 20)
+
+  let cursor = 0
+  if (page > 0) {
+    cursor = (page - 1) * count
+  }
+
+  return qs.stringify({
+    WebIdLastTime: Date.now(),
+    aid: 1988,
+    app_language: "en",
+    app_name: "tiktok_web",
+    browser_language: "en-US",
+    browser_name: "Mozilla",
+    browser_online: true,
+    browser_platform: "Linux x86_64",
+    browser_version: "5.0 (X11)",
+    channel: "tiktok_web",
+    cookie_enabled: true,
+    count,
+    cursor: cursor.toString(),
+    data_collection_enabled: true,
+    device_id: generateDeviceId(),
+    device_platform: "web_pc",
+    focus_state: true,
+    from_page: "user",
+    history_len: 1,
+    is_fullscreen: false,
+    is_page_visible: true,
+    language: "en",
+    mixId: playlistId,
+    odinId: generateOdinId(),
+    os: "linux",
+    priority_region: "NZ",
+    referer: "",
+    region: "NZ",
+    screen_height: 1440,
+    screen_width: 2560,
     tz_name: "Pacific/Auckland",
     user_is_login: true,
     verifyFp: "verify_lacphy8d_z2ux9idt_xdmu_4gKb_9nng_NNTTTvsFS8ao",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,9 @@
 import { TiktokAPIResponse } from "./types/downloader/tiktokApi"
 import { SSSTikResponse } from "./types/downloader/ssstik"
 import { MusicalDownResponse } from "./types/downloader/musicaldown"
-import {
-  TiktokUserSearchResponse,
-  UserSearchResult
-} from "./types/search/userSearch"
-import {
-  TiktokLiveSearchResponse,
-  LiveSearchResult
-} from "./types/search/liveSearch"
-import {
-  TiktokVideoSearchResponse,
-  VideoSearchResult
-} from "./types/search/videoSearch"
+import { UserSearchResult } from "./types/search/userSearch"
+import { LiveSearchResult } from "./types/search/liveSearch"
+import { VideoSearchResult } from "./types/search/videoSearch"
 import { TiktokStalkUserResponse } from "./types/get/getProfile"
 import { TiktokVideoCommentsResponse } from "./types/get/getComments"
 import { TiktokUserPostsResponse } from "./types/get/getUserPosts"
@@ -21,7 +12,7 @@ import { TiktokUserFavoriteVideosResponse } from "./types/get/getUserLiked"
 import { TiktokCollectionResponse } from "./types/get/getCollection"
 
 /** Services */
-import { TiktokAPI } from "./utils/downloader/tiktokApi"
+import { extractPlaylistId, TiktokAPI } from "./utils/downloader/tiktokApi"
 import { SSSTik } from "./utils/downloader/ssstik"
 import { MusicalDown } from "./utils/downloader/musicalDown"
 import { StalkUser } from "./utils/get/getProfile"
@@ -38,6 +29,8 @@ import { extractCollectionId } from "./utils/downloader/tiktokApi"
 import { DOWNLOADER_VERSIONS, SEARCH_TYPES } from "./constants"
 import { ERROR_MESSAGES } from "./constants"
 import { validateCookie } from "./utils/validator"
+import { TiktokPlaylistResponse } from "./types/get/getPlaylist"
+import { getPlaylist } from "./utils/get/getPlaylist"
 
 /** Types */
 type DownloaderVersion = "v1" | "v2" | "v3"
@@ -149,7 +142,12 @@ export = {
         message: "Invalid collection ID or URL format"
       }
     }
-    return await getCollection(collectionId, options?.proxy, options?.page, options?.count)
+    return await getCollection(
+      collectionId,
+      options?.proxy,
+      options?.page,
+      options?.count
+    )
   },
 
   /**
@@ -313,6 +311,38 @@ export = {
       options.cookie,
       options?.proxy,
       options?.postLimit
+    )
+  },
+
+  /**
+   * Get TikTok Playlist
+   * @param {string} url - URL (e.g. https://www.tiktok.com/@username/playlist/name-id)
+   * @param {Object} options - The options for playlist
+   * @param {string} [options.proxy] - Optional proxy URL
+   * @param {string} [options.page] - Optional page for pagination
+   * @param {number} [options.count] - Optional number of items to fetch(max: 20)
+   * @returns {Promise<TiktokPlaylistResponse>}
+   */
+  Playlist: async (
+    url: string,
+    options?: {
+      proxy?: string
+      page?: number
+      count?: number
+    }
+  ): Promise<TiktokPlaylistResponse> => {
+    const playlistId = extractPlaylistId(url)
+    if (!playlistId) {
+      return {
+        status: "error",
+        message: "Invalid playlist ID or URL format"
+      }
+    }
+    return await getPlaylist(
+      playlistId,
+      options?.proxy,
+      options?.page,
+      options?.count
     )
   }
 }

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -48,8 +48,8 @@ async function handleMediaDownload(
 
   const { result } = data
   const author = result.author
-  const username =
-    version === "v1" ? author.username : version === "v2" ? author.nickname : ""
+  console.log(result)
+  const username = version === "v1" ? author.username : author?.nickname || ""
 
   Logger.success(
     `${

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -48,7 +48,8 @@ async function handleMediaDownload(
 
   const { result } = data
   const author = result.author
-  const username = version === "v1" ? author.username : author.nickname
+  const username =
+    version === "v1" ? author.username : version === "v2" ? author.nickname : ""
 
   Logger.success(
     `${
@@ -63,7 +64,7 @@ async function handleMediaDownload(
         version === "v1"
           ? result.video.downloadAddr[0]
           : version === "v2"
-          ? result.video
+          ? result.video.playAddr[0]
           : result.videoHD
       const videoName = `ttdl_${username}_${Date.now()}.mp4`
 

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -48,7 +48,6 @@ async function handleMediaDownload(
 
   const { result } = data
   const author = result.author
-  console.log(result)
   const username = version === "v1" ? author.username : author?.nickname || ""
 
   Logger.success(

--- a/src/types/get/getPlaylist.ts
+++ b/src/types/get/getPlaylist.ts
@@ -1,16 +1,30 @@
 import {
-  StatisticsTiktokAPI,
+  AuthorTiktokAPI,
   MusicTiktokAPI,
   VideoTiktokAPI
 } from "../downloader/tiktokApi"
-import { PlaylistAuthor } from "./getPlaylist"
 
-export interface CollectionItem {
+export interface PlaylistAuthor
+  extends Omit<AuthorTiktokAPI, "username" | "uid"> {
+  avatarLarger: string
+  nickname: string
+  id: string
+}
+
+interface Statistics {
+  collectCount: number
+  commentCount: number
+  diggCount: number
+  playCount: number
+  shareCount: number
+}
+
+export interface PlaylistItem {
   id: string
   desc: string
   createTime: number
   author: PlaylistAuthor
-  statistics: StatisticsTiktokAPI
+  stats: Statistics
   video: VideoTiktokAPI
   music: MusicTiktokAPI
   challenges: Array<{
@@ -44,12 +58,12 @@ export interface CollectionItem {
   }>
 }
 
-export interface TiktokCollectionResponse {
+export interface TiktokPlaylistResponse {
   status: "success" | "error"
   message?: string
   result?: {
     hasMore: boolean
-    itemList: CollectionItem[]
+    itemList: PlaylistItem[]
     extra?: {
       fatal_item_ids: string[]
       logid: string

--- a/src/utils/downloader/musicalDown.ts
+++ b/src/utils/downloader/musicalDown.ts
@@ -1,19 +1,14 @@
 import Axios from "axios"
 import { load } from "cheerio"
-type CheerioAPI = ReturnType<typeof load>
 import {
   MusicalDownResponse,
-  GetMusicalDownMusic,
   GetMusicalDownReuqest
 } from "../../types/downloader/musicaldown"
-import {
-  _musicaldownapi,
-  _musicaldownmusicapi,
-  _musicaldownurl
-} from "../../constants/api"
+import { _musicaldownapi, _musicaldownurl } from "../../constants/api"
 import { HttpsProxyAgent } from "https-proxy-agent"
 import { SocksProxyAgent } from "socks-proxy-agent"
 import { ERROR_MESSAGES } from "../../constants"
+type CheerioAPI = ReturnType<typeof load>
 
 /** Constants */
 const TIKTOK_URL_REGEX =
@@ -59,10 +54,10 @@ const isValidUrl = (url: string): boolean => {
   }
 }
 
-const extractRequestForm = ($: CheerioAPI): RequestForm => {
+const extractRequestForm = ($: CheerioAPI, url: string): RequestForm => {
   const input = $("div > input").map((_, el) => $(el))
   return {
-    [input.get(0).attr("name") || ""]: input.get(0).attr("value") || "",
+    [input.get(0).attr("name") || ""]: input.get(0).attr("value") || url,
     [input.get(1).attr("name") || ""]: input.get(1).attr("value") || "",
     [input.get(2).attr("name") || ""]: input.get(2).attr("value") || ""
   }
@@ -170,7 +165,7 @@ const getRequest = async (
     }
 
     const $ = load(data)
-    const request = extractRequestForm($)
+    const request = extractRequestForm($, url)
 
     return {
       status: "success",

--- a/src/utils/downloader/tiktokApi.ts
+++ b/src/utils/downloader/tiktokApi.ts
@@ -1,7 +1,16 @@
 import Axios from "axios"
 import asyncRetry from "async-retry"
-import { _tiktokvFeed, _tiktokurl, _tiktokGetCollection } from "../../constants/api"
-import { _tiktokApiParams, _getCollectionParams } from "../../constants/params"
+import {
+  _tiktokvFeed,
+  _tiktokurl,
+  _tiktokGetCollection,
+  _tiktokGetPlaylist
+} from "../../constants/api"
+import {
+  _tiktokApiParams,
+  _getCollectionParams,
+  _getPlaylistParams
+} from "../../constants/params"
 import {
   AuthorTiktokAPI,
   TiktokAPIResponse,
@@ -14,6 +23,7 @@ import {
 import { HttpsProxyAgent } from "https-proxy-agent"
 import { SocksProxyAgent } from "socks-proxy-agent"
 import { ERROR_MESSAGES } from "../../constants"
+import { TiktokPlaylistResponse } from "../../types/get/getPlaylist"
 
 /** Constants */
 const TIKTOK_URL_REGEX =
@@ -21,6 +31,7 @@ const TIKTOK_URL_REGEX =
 const USER_AGENT =
   "com.zhiliaoapp.musically/300904 (2018111632; U; Android 10; en_US; Pixel 4; Build/QQ3A.200805.001; Cronet/58.0.2991.0)"
 const COLLECTION_URL_REGEX = /collection\/[^/]+-(\d+)/
+const PLAYLIST_URL_REGEX = /playlist\/[^/]+-(\d+)/
 
 /** Types */
 interface ProxyConfig {
@@ -200,7 +211,7 @@ const createVideoResponse = (
 const handleRedirect = async (url: string, proxy?: string): Promise<string> => {
   try {
     const response = await Axios(url, {
-      method: 'HEAD',
+      method: "HEAD",
       maxRedirects: 5,
       validateStatus: (status) => status >= 200 && status < 400,
       ...createProxyAgent(proxy)
@@ -210,9 +221,9 @@ const handleRedirect = async (url: string, proxy?: string): Promise<string> => {
     const finalUrl = response.request.res.responseUrl
 
     // Remove query parameters
-    return finalUrl.split('?')[0]
+    return finalUrl.split("?")[0]
   } catch (error) {
-    console.error('Error handling redirect:', error)
+    console.error("Error handling redirect:", error)
     return url
   }
 }
@@ -225,6 +236,11 @@ export const extractCollectionId = (input: string): string | null => {
 
   // Try to extract from URL
   const match = input.match(COLLECTION_URL_REGEX)
+  return match ? match[1] : null
+}
+
+export const extractPlaylistId = (url: string): string | null => {
+  const match = url.match(PLAYLIST_URL_REGEX)
   return match ? match[1] : null
 }
 
@@ -302,17 +318,17 @@ export const TiktokAPI = async (
 export const Collection = async (
   collectionIdOrUrl: string,
   options?: {
-    page?: number,
-    proxy?: string,
+    page?: number
+    proxy?: string
     count?: number
   }
 ): Promise<TiktokCollectionResponse> => {
   try {
     // Only handle redirects if the input is a URL
-    const processedUrl = collectionIdOrUrl.startsWith('http') 
+    const processedUrl = collectionIdOrUrl.startsWith("http")
       ? await handleRedirect(collectionIdOrUrl, options?.proxy)
       : collectionIdOrUrl
-    
+
     const collectionId = extractCollectionId(processedUrl)
     if (!collectionId) {
       return {
@@ -358,7 +374,73 @@ export const Collection = async (
   } catch (error) {
     return {
       status: "error",
-      message: error instanceof Error ? error.message : ERROR_MESSAGES.NETWORK_ERROR
+      message:
+        error instanceof Error ? error.message : ERROR_MESSAGES.NETWORK_ERROR
+    }
+  }
+}
+
+export const Playlist = async (
+  url: string,
+  options?: {
+    page?: number
+    proxy?: string
+    count?: number
+  }
+): Promise<TiktokPlaylistResponse> => {
+  try {
+    const processedUrl = url.startsWith("http")
+      ? await handleRedirect(url, options?.proxy)
+      : url
+
+    const playlistId = extractPlaylistId(processedUrl)
+    if (!playlistId) {
+      return {
+        status: "error",
+        message: "Invalid playlist ID or URL format"
+      }
+    }
+
+    const response = await Axios(
+      _tiktokGetPlaylist(
+        _getPlaylistParams(playlistId, options.page, options.count)
+      ),
+      {
+        method: "GET",
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0",
+          Accept: "*/*",
+          "Accept-Language": "en-US,en;q=0.7",
+          Referer: "https://www.tiktok.com/",
+          Origin: "https://www.tiktok.com"
+        },
+        ...createProxyAgent(options?.proxy)
+      }
+    )
+
+    if (response.data && response.data.status_code === 0) {
+      const data = response.data
+
+      return {
+        status: "success",
+        result: {
+          itemList: data.itemList || [],
+          hasMore: data.hasMore,
+          extra: data.extra
+        }
+      }
+    }
+
+    return {
+      status: "error",
+      message: ERROR_MESSAGES.NETWORK_ERROR
+    }
+  } catch (error) {
+    return {
+      status: "error",
+      message:
+        error instanceof Error ? error.message : ERROR_MESSAGES.NETWORK_ERROR
     }
   }
 }

--- a/src/utils/get/getPlaylist.ts
+++ b/src/utils/get/getPlaylist.ts
@@ -1,0 +1,91 @@
+import Axios from "axios"
+import { _tiktokGetPlaylist, _tiktokurl } from "../../constants/api"
+import { _getPlaylistParams } from "../../constants/params"
+import { HttpsProxyAgent } from "https-proxy-agent"
+import { SocksProxyAgent } from "socks-proxy-agent"
+import { ERROR_MESSAGES } from "../../constants"
+import retry from "async-retry"
+import { TiktokPlaylistResponse } from "../../types/get/getPlaylist"
+
+/** Types */
+interface ProxyConfig {
+  httpsAgent?: HttpsProxyAgent<string> | SocksProxyAgent
+}
+
+const createProxyAgent = (proxy?: string): ProxyConfig => {
+  if (!proxy) return {}
+
+  if (proxy.startsWith("socks")) {
+    return {
+      httpsAgent: new SocksProxyAgent(proxy)
+    }
+  }
+
+  return {
+    httpsAgent: new HttpsProxyAgent(proxy)
+  }
+}
+
+/**
+ * Get TikTok Collection
+ * @param {string} collectionId - Collection ID
+ * @param {string} proxy - Your Proxy (optional)
+ * @param {string} page - Page for pagination (optional)
+ * @param {number} count - Number of items to fetch (optional)
+ * @returns {Promise<TiktokPlaylistResponse>}
+ */
+export const getPlaylist = async (
+  playlistId: string,
+  proxy?: string,
+  page: number = 1,
+  count: number = 5
+): Promise<TiktokPlaylistResponse> => {
+  try {
+    const response = await retry(
+      async () => {
+        const res = await Axios(
+          _tiktokGetPlaylist(_getPlaylistParams(playlistId, page, count)),
+          {
+            method: "GET",
+            headers: {
+              "User-Agent":
+                "Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0",
+              Accept: "*/*",
+              "Accept-Language": "en-US,en;q=0.7",
+              Referer: "https://www.tiktok.com/",
+              Origin: "https://www.tiktok.com",
+              "Content-Type": "application/json",
+            },
+            ...createProxyAgent(proxy)
+          }
+        )
+
+        if (res.data && res.data.statusCode === 0) {
+          return res.data
+        }
+
+        throw new Error(ERROR_MESSAGES.NETWORK_ERROR)
+      },
+      {
+        retries: 20,
+        minTimeout: 200,
+        maxTimeout: 1000
+      }
+    )
+
+    return {
+      status: "success",
+      result: {
+        hasMore: response.hasMore,
+        itemList: response.itemList || [],
+        extra: response.extra,
+      }
+    }
+  } catch (error) {
+    return {
+      status: "error",
+      message:
+        error instanceof Error ? error.message : ERROR_MESSAGES.NETWORK_ERROR
+    }
+  }
+}


### PR DESCRIPTION
What’s fixed

- Fixed broken request payload in musicalDown (v3).
   It now correctly includes the url, which was missing due to bad fallback logic [here](https://github.com/TobyG74/tiktok-api-dl/blob/b5955b75b44f877c1d8b9992d131e72961ac289d/src/utils/downloader/musicalDown.ts#L65) (|| "" was wiping it).
   
- Improved username fallback for slider/image posts.
    Now `uses author?.nickname || ""` when username is unavailable.

Whats's new

- TikTok Playlist Parsing Support
  It can now parse and handle contents from TikTok playlists too